### PR TITLE
Fix: Proper plurality in `/fuy wars`

### DIFF
--- a/src/main/java/com/busted_moments/client/commands/FuyCommand.java
+++ b/src/main/java/com/busted_moments/client/commands/FuyCommand.java
@@ -146,7 +146,7 @@ public class FuyCommand {
       ChatUtil.message(
               TextBuilder.of("You have entered ", GRAY)
                       .append(wars, AQUA)
-                      .append(" wars", GRAY).appendIf(() -> wars > 1, "s", GRAY)
+                      .append(" war", GRAY).appendIf(() -> wars > 1, "s", GRAY)
                       .append(" in the past ")
                       .append(range.toString(), AQUA).append(".", GRAY)
       );


### PR DESCRIPTION
Fixes the following:

![image](https://github.com/Essentuan/fuy.gg/assets/34697715/adce2bf6-d373-4b28-85d3-da6413cc2909)