### PR TITLE
Fixes the `0` case in `/fuy wars`

### DIFF
--- a/src/main/java/com/busted_moments/client/commands/FuyCommand.java
+++ b/src/main/java/com/busted_moments/client/commands/FuyCommand.java
@@ -146,7 +146,7 @@ public class FuyCommand {
       ChatUtil.message(
               TextBuilder.of("You have entered ", GRAY)
                       .append(wars, AQUA)
-                      .append(" war", GRAY).appendIf(() -> wars > 1, "s", GRAY)
+                      .append(" war", GRAY).appendIf(() -> (wars != 1), "s", GRAY)
                       .append(" in the past ")
                       .append(range.toString(), AQUA).append(".", GRAY)
       );


### PR DESCRIPTION
Essentuan didn't account for this but I'm fixing it anyways.

I am like a little baby when it comes to Java and I can't test this since it won't compile (making a VM soon:tm:) so let me know if there's a better way to do this, or if this plain just doesn't work