### PR TITLE
Fix AutoSkipDialogueFeature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 1.2.4
+mod_version = 1.2.5
 maven_group = com.busted_moments
 archives_base_name = fuy_gg
 

--- a/src/main/java/com/busted_moments/client/features/AutoSkipDialogueFeature.java
+++ b/src/main/java/com/busted_moments/client/features/AutoSkipDialogueFeature.java
@@ -4,6 +4,7 @@ import com.busted_moments.client.util.PacketUtil;
 import com.busted_moments.core.Feature;
 import com.busted_moments.core.heartbeat.Heartbeat;
 import com.busted_moments.core.time.TimeUnit;
+import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.handlers.chat.event.NpcDialogEvent;
 import com.wynntils.handlers.chat.type.NpcDialogueType;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -15,6 +16,15 @@ public class AutoSkipDialogueFeature extends Feature {
     @SubscribeEvent
     public void NpcDialogEvent(NpcDialogEvent event) {
         if (event.getType() != NpcDialogueType.NORMAL) return;
+
+        PacketUtil.Action(Action.PRESS_SHIFT_KEY);
+
+        Heartbeat.schedule(() -> PacketUtil.Action(Action.RELEASE_SHIFT_KEY), 50, TimeUnit.MILLISECONDS);
+    }
+
+    @SubscribeEvent
+    public void ChatReceivedEvent(ChatMessageReceivedEvent event){
+        if (!event.getStyledText().contains("§7Press §fSHIFT §7to continue§r")) return;
 
         PacketUtil.Action(Action.PRESS_SHIFT_KEY);
 

--- a/src/main/java/com/busted_moments/client/features/AutoSkipDialogueFeature.java
+++ b/src/main/java/com/busted_moments/client/features/AutoSkipDialogueFeature.java
@@ -7,6 +7,7 @@ import com.busted_moments.core.time.TimeUnit;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.handlers.chat.event.NpcDialogEvent;
 import com.wynntils.handlers.chat.type.NpcDialogueType;
+import com.wynntils.handlers.chat.type.RecipientType;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import static net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket.Action;
@@ -24,7 +25,7 @@ public class AutoSkipDialogueFeature extends Feature {
 
     @SubscribeEvent
     public void ChatReceivedEvent(ChatMessageReceivedEvent event){
-        if (!event.getStyledText().contains("§7Press §fSHIFT §7to continue§r")) return;
+        if (event.getRecipientType() == RecipientType.NPC) return;
 
         PacketUtil.Action(Action.PRESS_SHIFT_KEY);
 

--- a/src/main/java/com/busted_moments/client/features/AutoSkipDialogueFeature.java
+++ b/src/main/java/com/busted_moments/client/features/AutoSkipDialogueFeature.java
@@ -4,6 +4,7 @@ import com.busted_moments.client.util.PacketUtil;
 import com.busted_moments.core.Feature;
 import com.busted_moments.core.heartbeat.Heartbeat;
 import com.busted_moments.core.time.TimeUnit;
+import com.wynntils.core.text.PartStyle;
 import com.wynntils.handlers.chat.event.ChatMessageReceivedEvent;
 import com.wynntils.handlers.chat.event.NpcDialogEvent;
 import com.wynntils.handlers.chat.type.NpcDialogueType;
@@ -14,6 +15,8 @@ import static net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket
 
 @Feature.Definition(name = "Autoskip Dialogue", description = "Automatically skips dialogue")
 public class AutoSkipDialogueFeature extends Feature {
+    private static final String PRESS_TO_CONTINUE_TEXT = "Press SHIFT to continue";
+
     @SubscribeEvent
     public void NpcDialogEvent(NpcDialogEvent event) {
         if (event.getType() != NpcDialogueType.NORMAL) return;
@@ -25,8 +28,8 @@ public class AutoSkipDialogueFeature extends Feature {
 
     @SubscribeEvent
     public void ChatReceivedEvent(ChatMessageReceivedEvent event){
-        if (event.getRecipientType() == RecipientType.NPC) return;
-
+        if (event.getRecipientType() != RecipientType.INFO || !event.getStyledText().trim().contains(PRESS_TO_CONTINUE_TEXT, PartStyle.StyleType.NONE)) return;
+        
         PacketUtil.Action(Action.PRESS_SHIFT_KEY);
 
         Heartbeat.schedule(() -> PacketUtil.Action(Action.RELEASE_SHIFT_KEY), 50, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Before if you had NPC Dialogue(s) disabled in Wynntils this feature would not work.