### PR TITLE
Added 4 new options for the territory helper menu

### DIFF
--- a/src/main/java/com/busted_moments/client/features/war/TerritoryHelperMenuFeature.java
+++ b/src/main/java/com/busted_moments/client/features/war/TerritoryHelperMenuFeature.java
@@ -59,6 +59,13 @@ public class TerritoryHelperMenuFeature extends Feature {
       return new HashSet<>(Arrays.asList(ignoredTerritories.split(",")));
    }
 
+   @Value("Hide ignored territories")
+   static boolean hideIgnoredTerritories = false;
+
+   public static boolean getHideIgnoredTerritories() {
+      return hideIgnoredTerritories;
+   }
+
    @Value("Display production")
    static boolean production = true;
 

--- a/src/main/java/com/busted_moments/client/features/war/TerritoryHelperMenuFeature.java
+++ b/src/main/java/com/busted_moments/client/features/war/TerritoryHelperMenuFeature.java
@@ -25,10 +25,40 @@ import static com.busted_moments.client.screen.territories.ManageTerritoriesScre
 import static com.busted_moments.client.screen.territories.SelectTerritoriesScreen.SELECT_TERRITORIES_MENU;
 import static com.wynntils.utils.mc.McUtils.mc;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 @Config.Category("War")
 @Default(State.ENABLED)
 @Feature.Definition(name = "Territory Helper Menu")
 public class TerritoryHelperMenuFeature extends Feature {
+   @Value("Ignore No Route Resources")
+   static boolean ignoreNoRoute = false;
+
+   @Value("Reset Filters On Menu Exit")
+   static boolean resetFiltersOnMenuExit = false;
+
+   @Value("Use blacklist")
+	static boolean useBlacklist = false;
+
+   public static boolean getResetFiltersOnMenuExit() {
+      return resetFiltersOnMenuExit;
+   }
+   public static boolean getIgnoreNoRoute() {
+      return ignoreNoRoute;
+   }
+   public static boolean getUseBlacklist() {
+      return useBlacklist;
+   }
+
+   @Value("Ignore resources from")
+   static String ignoredTerritories = "Light Forest West Upper,Light Forest West Mid,Light Forest East Lower,Light Forest East Mid,Light Forest Canyon,Aldorei Valley South Entrance,Aldorei's North Exit,Cinfras County Lower,Path To The Arch,Ghostly Path,Aldorei's Arch,Burning Farm,Heavenly Ingress,Primal Fen,Luminous Plateau,Field of Life,Path to Light,Otherwordly Monolith,Azure Frontier,Nexus of Light,Jungle Lake,Herb Cave,Great Bridge Jungle,Jungle Lower,Jungle Mid,Jungle Upper,Dernel Jungle Mid,Dernel Jungle Lower,Dernel Jungle Upper";
+
+   public static Set<String> getIgnoredTerritories() {
+      return new HashSet<>(Arrays.asList(ignoredTerritories.split(",")));
+   }
+
    @Value("Display production")
    static boolean production = true;
 

--- a/src/main/java/com/busted_moments/client/models/territory/eco/types/EcoConstants.java
+++ b/src/main/java/com/busted_moments/client/models/territory/eco/types/EcoConstants.java
@@ -20,6 +20,7 @@ public interface EcoConstants {
    }
 
    static long getStorage(ResourceType type, TerritoryEco eco) {
+      if (eco == null) return 0;
       var storage = (type == ResourceType.EMERALDS) ? getEmeraldStorage(eco.isHQ()) : getResourceStorage(eco.isHQ());
 
       return (long) (((eco.getUpgrade(type == ResourceType.EMERALDS ? UpgradeType.EMERALD_STORAGE : UpgradeType.RESOURCE_STORAGE).bonus() / 100) + 1) * storage);

--- a/src/main/java/com/busted_moments/client/screen/territories/TerritoryScreen.java
+++ b/src/main/java/com/busted_moments/client/screen/territories/TerritoryScreen.java
@@ -244,13 +244,12 @@ public abstract class TerritoryScreen<Scanner extends TerritoryScanner> extends 
       Map<ResourceType, Long> tributes = TributeModel.getNetTributes();
 
       for (TerritoryEco entry : this.territories) {
+         if (entry.getRoute().isEmpty() && TerritoryHelperMenuFeature.getIgnoreNoRoute())
+            continue;
+
+         if (TerritoryHelperMenuFeature.getIgnoredTerritories().contains(entry.getName()) && TerritoryHelperMenuFeature.getUseBlacklist())
+            continue;
          for (ResourceType resource : ResourceType.values()) {
-            if (entry.getRoute().isEmpty() && TerritoryHelperMenuFeature.getIgnoreNoRoute())
-               continue;
-
-            if (TerritoryHelperMenuFeature.getIgnoredTerritories().contains(entry.getName()) && TerritoryHelperMenuFeature.getUseBlacklist())
-               continue;
-
             production.compute(resource, (r, total) -> {
                var prod = entry.getProduction(resource);
                if (total == null) return prod;
@@ -285,7 +284,19 @@ public abstract class TerritoryScreen<Scanner extends TerritoryScanner> extends 
 
       for (int i = 0; i < territories.size(); i++) {
          var entry = territories.get(i);
+         if (TerritoryHelperMenuFeature.getHideIgnoredTerritories()) {
+            if (
+            TerritoryHelperMenuFeature.getIgnoreNoRoute() &&
+            entry.getRoute().isEmpty()
+            )
+            continue;
 
+            if (
+            TerritoryHelperMenuFeature.getUseBlacklist() &&
+            TerritoryHelperMenuFeature.getIgnoredTerritories().contains(entry.getName())
+            )
+            continue;
+         }
          entry(entry)
                  .update(i, position)
                  .tooltip()
@@ -301,7 +312,7 @@ public abstract class TerritoryScreen<Scanner extends TerritoryScanner> extends 
                  String symbol = resource.getPrettySymbol();
 
                  var color = resource.getColor();
-                 TerritoryEco.Storage s = storage.get(resource);
+                 TerritoryEco.Storage s = storage.getOrDefault(resource, TerritoryEco.Storage.empty(resource, null));
 
                  builder
                          .append(symbol)

--- a/src/main/java/com/busted_moments/client/screen/territories/TerritoryScreen.java
+++ b/src/main/java/com/busted_moments/client/screen/territories/TerritoryScreen.java
@@ -245,6 +245,12 @@ public abstract class TerritoryScreen<Scanner extends TerritoryScanner> extends 
 
       for (TerritoryEco entry : this.territories) {
          for (ResourceType resource : ResourceType.values()) {
+            if (entry.getRoute().isEmpty() && TerritoryHelperMenuFeature.getIgnoreNoRoute())
+               continue;
+
+            if (TerritoryHelperMenuFeature.getIgnoredTerritories().contains(entry.getName()) && TerritoryHelperMenuFeature.getUseBlacklist())
+               continue;
+
             production.compute(resource, (r, total) -> {
                var prod = entry.getProduction(resource);
                if (total == null) return prod;

--- a/src/main/java/com/busted_moments/client/screen/territories/filter/FilterMenu.java
+++ b/src/main/java/com/busted_moments/client/screen/territories/filter/FilterMenu.java
@@ -1,6 +1,7 @@
 package com.busted_moments.client.screen.territories.filter;
 
 import com.busted_moments.client.features.keybinds.Keybind;
+import com.busted_moments.client.features.war.TerritoryHelperMenuFeature;
 import com.busted_moments.client.util.SoundUtil;
 import com.busted_moments.core.render.FontRenderer;
 import com.busted_moments.core.render.screen.Widget;
@@ -22,7 +23,7 @@ import java.util.function.Consumer;
 public abstract class FilterMenu extends Widget<FilterMenu> {
    final static StyledText LEGEND = getLegend(null, Set.of(Filter.values()), null);
 
-   private final Set<Filter> selected = new HashSet<>(List.of(Filter.values()));
+   private static Set<Filter> selected = new HashSet<>(List.of(Filter.values()));
 
    private Multimap<Filter, ?> counts = null;
 
@@ -30,6 +31,7 @@ public abstract class FilterMenu extends Widget<FilterMenu> {
    };
 
    public FilterMenu() {
+      if (TerritoryHelperMenuFeature.getResetFiltersOnMenuExit()) selected = new HashSet<>(List.of(Filter.values()));
       setSize(
               FontRenderer.getWidth(FilterMenu.LEGEND, 0),
               FontRenderer.getHeight(FilterMenu.LEGEND, 0)


### PR DESCRIPTION
Do not wish my peers to be having strokes trying to eco when we have FFA. 

- Added an option to blacklist (and ignore) territories resources with the default list of regular FFAs. 
- Added an option to ignore resources from territories with no route.
- Added an option to hide ignored territories from territory list.
- Added an option to not reset the territory filters when you exit the menu out.
